### PR TITLE
Add mobile navbar burger functionality

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -17,11 +17,19 @@ export class Sidebar extends Component {
         { content: 'Interests', href: 'interests' },
         { content: 'Awards', href: 'awards' },
       ],
+      isCollapsed: true,
     };
+    this.toggleNavbar = this.toggleNavbar.bind(this);
+  }
+
+  toggleNavbar() {
+    this.setState({
+      isCollapsed: !this.state.isCollapsed,
+    });
   }
 
   render() {
-    const { tabs } = this.state;
+    const { tabs, isCollapsed } = this.state;
     return (
       <nav
         className="navbar navbar-expand-lg navbar-dark bg-primary fixed-top"
@@ -40,17 +48,20 @@ export class Sidebar extends Component {
           </span>
         </a>
         <button
-          className="navbar-toggler"
+          className={`navbar-toggler navbar-toggler-right ${
+            isCollapsed ? 'collapsed' : ''
+            }`}
           type="button"
           data-toggle="collapse"
-          data-target="#navbarSupportedContent"
           aria-controls="navbarSupportedContent"
           aria-expanded="false"
           aria-label="Toggle navigation"
+          onClick={this.toggleNavbar}
         >
           <span className="navbar-toggler-icon"></span>
         </button>
-        <div className="collapse navbar-collapse" id="navbarSupportedContent">
+        <div className={`collapse navbar-collapse ${isCollapsed ? '' : 'show'}`}
+          id="navbarSupportedContent">
           <Scrollspy
             items={tabs.map(s => s.href)}
             currentClassName="active"


### PR DESCRIPTION
# Problem
When the screen size is small, the sidebar automatically collapses into a hamburger menu. However, the hamburger menu does not work when you use React and Bootstrap (See: https://www.bennettnotes.com/bootstrap-navbar-collapse-reactjs/#)

# Solution

Set the classnames manually using React. Classnames are changed when the hamburger button is clicked.

I've made the relevant changes on my website as well. 
Website: https://www.khanguslee.dev/

# Other

- The hamburger drop down does not close if you click elsewhere.

# Issue

This solves issue https://github.com/anubhavsrivastava/gatsby-starter-resume/issues/2

# Credits

Credits to @chuckwilliams37 for resolving the issue in his own repo: https://github.com/chuckwilliams37/screenscholar-resume/blob/master/src/components/Sidebar.js

